### PR TITLE
Remove `valid-url` use Joi instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "string": "^3.1.0",
     "super-request": "0.0.8",
     "supertest": "^0.13.0",
-    "supertest-as-promised": "^1.0.0",
-    "valid-url": "^1.0.9"
+    "supertest-as-promised": "^1.0.0"
   }
 }

--- a/test/v1_0_2/non_templating.js
+++ b/test/v1_0_2/non_templating.js
@@ -5,7 +5,7 @@
  * https://github.com/adlnet/xAPI_LRS_Test/blob/master/TestingRequirements.md
  *
  */
-(function (module, fs, extend, moment, request, requestPromise, qs, chai, validUrl, helper, multipartParser) {
+(function (module, fs, extend, moment, request, requestPromise, qs, chai, Joi, helper, multipartParser) {
     "use strict";
 
     var expect = chai.expect;
@@ -1038,7 +1038,7 @@
                     } else {
                         var result = parse(res.body, done);
                         expect(result).to.have.property('more');
-                        expect(validUrl.isUri(result.more)).to.be.truthy;
+                        Joi.assert(result.more, Joi.string().uri());
                         done();
                     }
                 });
@@ -1076,7 +1076,7 @@
                     } else {
                         var result = parse(res.body, done);
                         expect(result).to.have.property('more');
-                        expect(validUrl.isUri(result.more)).to.be.truthy;
+                        Joi.assert(result.more, Joi.string().uri());
                         done();
                     }
                 });
@@ -3729,5 +3729,5 @@
         return parsed;
     }
 
-}(module, require('fs'), require('extend'), require('moment'), require('super-request'), require('supertest-as-promised'), require('qs'), require('chai'), require('valid-url'), require('./../helper'), require('./../multipartParser')));
+}(module, require('fs'), require('extend'), require('moment'), require('super-request'), require('supertest-as-promised'), require('qs'), require('chai'), require('joi'), require('./../helper'), require('./../multipartParser')));
 


### PR DESCRIPTION
This PR removes the usage of the `valid-url` module as it doesn't actually validate the URI against RFC-3986 but instead just checks that the URI looks like it is the valid format. In place of the module `Joi` has been used which is already used in the Project and has an implementation which actually validates that the URI is valid specific to RFC-3986.